### PR TITLE
caddy.container: make it WantedBy=default.target

### DIFF
--- a/caddy.container
+++ b/caddy.container
@@ -6,4 +6,4 @@ Image=docker.io/library/caddy:2.10.0-alpine
 PublishPort=8080:80
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
User systemd sessions don't have multi-user.target, instead the default.target should be used.

See https://www.freedesktop.org/software/systemd/man/latest/bootup.html